### PR TITLE
fix: Fix deploy workflow deadlock issue

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -10,10 +10,6 @@ on:
   push:
     branches: ["main"]
 
-concurrency:
-  group: ${{ github.event.inputs.environment || 'dev' }}
-  cancel-in-progress: true
-
 jobs:
   call-workflow:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v2

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -15,6 +15,7 @@ jobs:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v2
     concurrency:
       group: ${{ github.event.inputs.environment || 'dev' }}
+      cancel-in-progress: true
     with:
       app-name: ors
       environment: ${{ github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -10,12 +10,13 @@ on:
   push:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.event.inputs.environment || 'dev' }}
+  cancel-in-progress: true
+
 jobs:
   call-workflow:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v2
-    concurrency:
-      group: ${{ github.event.inputs.environment || 'dev' }}
-      cancel-in-progress: true
     with:
       app-name: ors
       environment: ${{ github.event.inputs.environment || 'dev' }}


### PR DESCRIPTION
Example failure: https://github.com/mbta/ors-deploy/actions/runs/8574266883

Turns out, mbta/workflows/.github/workflows/deploy-ecs.yml@v2 already defines a `concurrency` rule, so having our own as well was creating a deadlock.