### PR TITLE
chore: Add schedule for production deploys

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+  schedule:
+    # Runs every Monday and Thursday at 15:39 UTC, which is either
+    # 8:49 AM or 9:49 AM ET, depending on Daylight Savings Time. This
+    # is two hours before the prod deploy, so we can see how dev is
+    # doing before approving a prod deploy.
+    - cron: "49 13 * * 1,4"
 
 jobs:
   call-workflow:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -2,6 +2,12 @@ name: Deploy to Prod
 
 on:
   workflow_dispatch:
+  push:
+    branches: ["main"]
+  schedule:
+    # Runs every Monday and Thursday at 15:39 UTC, which is either
+    # 10:49 AM or 11:49 AM ET, depending on Daylight Savings Time.
+    - cron: "49 15 * * 1,4"
 
 jobs:
   call-workflow:


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207005109039605