### PR TITLE
fix: point build to cached geofabrik data

### DIFF
--- a/changesets/scripts/entrypoint.sh
+++ b/changesets/scripts/entrypoint.sh
@@ -27,7 +27,7 @@ while [[ $# -gt 0 ]]; do
     -k|--search-key)
       shift
       search_key=$(escape_spaces "$1")
-      shift 
+      shift
       ;;
     -v|--search-value)
       shift
@@ -65,7 +65,7 @@ if [[ "$cached" = true ]]; then
   echo "Using existing files/data.osm file"
 else
   echo "Downloading osm data"
-  wget http://download.geofabrik.de/north-america/us/massachusetts-latest.osm.pbf -O files/data.osm.pbf
+  wget https://mbta-map-tiles.s3.us-east-1.amazonaws.com/data/osm/massachusetts-latest.osm.pbf -O files/data.osm.pbf
 
   echo "Converting osm.pbf file to o5m format"
   osmconvert files/data.osm.pbf -o=files/data.o5m


### PR DESCRIPTION
Geofabrik caching 'taskforce': https://mbta.slack.com/archives/C044SC8SJVA/p1772811921087959

We have cached geofabrik data into our own S3 bucket, that we can now use instead of using geofabrik directly.